### PR TITLE
Fix Discord voice reconnect loop with DAVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ repositories {
     mavenCentral()
     maven { url = 'https://m2.dv8tion.net/releases' }  // JDA 전용 저장소
     maven { url = 'https://jitpack.io' }               // Lavaplayer 호스팅 가능
+    maven { url = 'https://maven.lavalink.dev/snapshots' }
 }
 
 springBoot {
@@ -62,7 +63,10 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.38'
 
     // JDA (Discord API)
-    implementation 'net.dv8tion:JDA:5.2.1'
+    implementation 'net.dv8tion:JDA:6.4.1'
+    implementation 'moe.kyokobot.libdave:adapter-jda:ce725965e'
+    implementation 'moe.kyokobot.libdave:impl-jni:ce725965e'
+    runtimeOnly 'moe.kyokobot.libdave:natives-linux-x86-64:ce725965e'
 
     // Lavaplayer (음악 재생)
     implementation 'dev.arbjerg:lavaplayer:2.2.2'

--- a/src/main/java/com/gahyeonbot/core/BotInitializer.java
+++ b/src/main/java/com/gahyeonbot/core/BotInitializer.java
@@ -1,7 +1,10 @@
 package com.gahyeonbot.core;
 
 import com.gahyeonbot.config.AppCredentialsConfig;
+import moe.kyokobot.libdave.NativeDaveFactory;
+import moe.kyokobot.libdave.jda.LDJDADaveSessionFactory;
 import net.dv8tion.jda.api.OnlineStatus;
+import net.dv8tion.jda.api.audio.AudioModuleConfig;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.sharding.DefaultShardManagerBuilder;
@@ -47,7 +50,10 @@ public class BotInitializer {
         }
 
         try {
+            var daveSessionFactory = new LDJDADaveSessionFactory(new NativeDaveFactory());
             return DefaultShardManagerBuilder.createDefault(token)
+                    .setAudioModuleConfig(new AudioModuleConfig()
+                            .withDaveSessionFactory(daveSessionFactory))
                     .setStatus(OnlineStatus.ONLINE)
                     .setActivity(Activity.playing("데이트"))
                     .enableIntents(


### PR DESCRIPTION
## Root cause
Discord now requires DAVE E2EE for voice connections. JDA 5.2.1 cannot negotiate it, causing the bot to repeatedly join and leave.

## Fix
- upgrade JDA to 6.4.1
- add libdave-jvm Java 21 JNI adapter and Linux x86_64 native
- configure AudioModuleConfig with a DAVE session factory

## Verification
- ./gradlew clean test bootJar