### PR TITLE
Use low-latency TTS for live assistant replies

### DIFF
--- a/src/main/java/com/gahyeonbot/services/assistant/AssistantProperties.java
+++ b/src/main/java/com/gahyeonbot/services/assistant/AssistantProperties.java
@@ -14,6 +14,7 @@ public class AssistantProperties {
     private int maxUtteranceSeconds = 20;
     private long silenceMillis = 900;
     private boolean speakResponses = true;
+    private String ttsProvider = "edge";
     private final Vad vad = new Vad();
     private final Stt stt = new Stt();
     private final OpenRouter openrouter = new OpenRouter();

--- a/src/main/java/com/gahyeonbot/services/assistant/VoiceAssistantService.java
+++ b/src/main/java/com/gahyeonbot/services/assistant/VoiceAssistantService.java
@@ -207,7 +207,8 @@ public class VoiceAssistantService {
 
         private void speak(String answer) throws Exception {
             for (String segment : ttsService.prepareSegments(answer)) {
-                Path audio = ttsService.synthesizeSegmentToAudio(segment);
+                Path audio = ttsService.synthesizeSegmentToAudio(
+                        segment, properties.getTtsProvider());
                 audioManager.getPlayerManager().loadItem(audio.toString(), new AudioLoadResultHandler() {
                     @Override public void trackLoaded(AudioTrack track) {
                         track.setUserData(new TtsTrackMetadata(audio, true));

--- a/src/main/java/com/gahyeonbot/services/tts/TtsService.java
+++ b/src/main/java/com/gahyeonbot/services/tts/TtsService.java
@@ -45,7 +45,11 @@ public class TtsService {
     }
 
     public Path synthesizeSegmentToAudio(String text) throws Exception {
-        TtsProvider selected = findProvider(props.getProvider());
+        return synthesizeSegmentToAudio(text, props.getProvider());
+    }
+
+    public Path synthesizeSegmentToAudio(String text, String provider) throws Exception {
+        TtsProvider selected = findProvider(provider);
         if (selected.isReady()) {
             try {
                 return selected.synthesize(text);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -106,6 +106,7 @@ assistant:
   max-utterance-seconds: ${ASSISTANT_MAX_UTTERANCE_SECONDS:20}
   silence-millis: ${ASSISTANT_SILENCE_MILLIS:900}
   speak-responses: ${ASSISTANT_SPEAK_RESPONSES:true}
+  tts-provider: ${ASSISTANT_TTS_PROVIDER:edge}
   vad:
     enabled: ${ASSISTANT_VAD_ENABLED:true}
     hop-size: ${ASSISTANT_VAD_HOP_SIZE:256}


### PR DESCRIPTION
Voice input, local Whisper, and OpenRouter were working, but CPU Qwen voice cloning blocked each reply for minutes. Keep Voicebox cloned voice for /tts and use configurable Edge TTS for live assistant responses.\n\nVerified: ./gradlew clean test bootJar