### PR TITLE
Fix live assistant Edge TTS runtime

### DIFF
--- a/scripts/edge_tts_server.py
+++ b/scripts/edge_tts_server.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import asyncio
+import json
+import os
+import tempfile
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import edge_tts
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path != "/health":
+            self.send_error(404)
+            return
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def do_POST(self):
+        if self.path != "/synthesize":
+            self.send_error(404)
+            return
+        try:
+            size = int(self.headers.get("Content-Length", "0"))
+            request = json.loads(self.rfile.read(size))
+            text = str(request["text"]).strip()
+            if not text or len(text) > 1000:
+                raise ValueError("invalid text")
+            fd, path = tempfile.mkstemp(suffix=".mp3")
+            os.close(fd)
+            try:
+                communicate = edge_tts.Communicate(
+                    text,
+                    request.get("voice", "ko-KR-SunHiNeural"),
+                    rate=request.get("rate", "+0%"),
+                    pitch=request.get("pitch", "+0Hz"),
+                )
+                asyncio.run(communicate.save(path))
+                with open(path, "rb") as audio:
+                    payload = audio.read()
+            finally:
+                os.unlink(path)
+            self.send_response(200)
+            self.send_header("Content-Type", "audio/mpeg")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        except Exception as exc:
+            self.send_error(500, str(exc))
+
+    def log_message(self, fmt, *args):
+        print(fmt % args, flush=True)
+
+
+ThreadingHTTPServer(("0.0.0.0", 8765), Handler).serve_forever()

--- a/src/main/java/com/gahyeonbot/services/tts/EdgeTtsProvider.java
+++ b/src/main/java/com/gahyeonbot/services/tts/EdgeTtsProvider.java
@@ -2,8 +2,11 @@ package com.gahyeonbot.services.tts;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
 
 import java.io.ByteArrayOutputStream;
+import java.time.Duration;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,8 +28,30 @@ public class EdgeTtsProvider implements TtsProvider {
         Files.createDirectories(dir);
         Path audio = Files.createTempFile(dir, "tts_edge_", ".mp3");
         try {
-            List<String> command = new ArrayList<>();
             var edge = properties.getEdge();
+            if (edge.getEndpoint() != null && !edge.getEndpoint().isBlank()) {
+                var factory = new org.springframework.http.client.SimpleClientHttpRequestFactory();
+                factory.setConnectTimeout(Duration.ofSeconds(properties.getTimeoutSeconds()));
+                factory.setReadTimeout(Duration.ofSeconds(properties.getTimeoutSeconds()));
+                HttpHeaders headers = new HttpHeaders();
+                headers.setContentType(MediaType.APPLICATION_JSON);
+                ResponseEntity<byte[]> response = new RestTemplate(factory).exchange(
+                        edge.getEndpoint(), HttpMethod.POST,
+                        new HttpEntity<>(java.util.Map.of(
+                                "text", text,
+                                "voice", edge.getVoice(),
+                                "rate", edge.getRate(),
+                                "pitch", edge.getPitch()), headers),
+                        byte[].class);
+                byte[] bytes = response.getBody();
+                if (bytes == null || bytes.length < 256) {
+                    throw new IllegalStateException("Edge TTS sidecar produced empty audio");
+                }
+                Files.write(audio, bytes);
+                return audio;
+            }
+
+            List<String> command = new ArrayList<>();
             command.add(edge.getBin());
             command.add("--voice");
             command.add(edge.getVoice());

--- a/src/main/java/com/gahyeonbot/services/tts/TtsProperties.java
+++ b/src/main/java/com/gahyeonbot/services/tts/TtsProperties.java
@@ -38,6 +38,8 @@ public class TtsProperties {
     public static class Edge {
         /** edge-tts executable. */
         private String bin = "edge-tts";
+        /** Optional HTTP sidecar endpoint returning MP3 bytes. */
+        private String endpoint;
 
         /** Korean female neural voice. */
         private String voice = "ko-KR-SunHiNeural";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,6 +77,7 @@ tts:
   timeout-seconds: ${TTS_TIMEOUT_SECONDS:20}
   edge:
     bin: ${TTS_EDGE_BIN:edge-tts}
+    endpoint: ${TTS_EDGE_ENDPOINT:}
     voice: ${TTS_EDGE_VOICE:ko-KR-SunHiNeural}
     rate: ${TTS_EDGE_RATE:+0%}
     pitch: ${TTS_EDGE_PITCH:+0Hz}


### PR DESCRIPTION
The assistant pipeline reached OpenRouter successfully, but the Java-only runtime could not execute the PVC Python venv. Add a localhost Python Edge TTS sidecar and HTTP synthesis path.\n\nVerified: ./gradlew clean test bootJar