### PR TITLE
Remove duplicate assistant action choices

### DIFF
--- a/src/main/java/com/gahyeonbot/commands/general/Assistant.java
+++ b/src/main/java/com/gahyeonbot/commands/general/Assistant.java
@@ -27,9 +27,6 @@ public class Assistant extends AbstractCommand {
     public List<OptionData> getOptions() {
         return List.of(new OptionData(OptionType.STRING, "action", "실행할 동작", true)
                 .setNameLocalization(DiscordLocale.KOREAN, "동작")
-                .addChoice("start", "start")
-                .addChoice("stop", "stop")
-                .addChoice("status", "status")
                 .addChoice("시작", "start")
                 .addChoice("종료", "stop")
                 .addChoice("상태", "status"));


### PR DESCRIPTION
Shows only the Korean 시작, 종료, 상태 choices while retaining the existing internal start, stop, status values.\n\nValidated with `./gradlew test`.