### PR TITLE
Keep voice connection open during assistant sessions

### DIFF
--- a/src/main/java/com/gahyeonbot/core/audio/TrackScheduler.java
+++ b/src/main/java/com/gahyeonbot/core/audio/TrackScheduler.java
@@ -70,10 +70,14 @@ public class TrackScheduler extends AudioEventAdapter {
      * 다음 트랙으로 넘어갑니다.
      */
     public void nextTrack() {
+        nextTrack(true);
+    }
+
+    private void nextTrack(boolean closeWhenEmpty) {
         AudioTrack nextTrack = trackQueue.pollTrack();
         if (nextTrack != null) {
             player.startTrack(nextTrack, false);
-        } else {
+        } else if (closeWhenEmpty) {
             closeConnection();
         }
     }
@@ -105,12 +109,13 @@ public class TrackScheduler extends AudioEventAdapter {
     @Override
     public void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
         cleanupIfTts(track);
-        if (endReason.mayStartNext) {
-            nextTrack();
-        } else {
+        boolean keepConnection = track != null
+                && track.getUserData() instanceof TtsTrackMetadata meta
+                && meta.keepConnection();
+        if (!endReason.mayStartNext) {
             System.out.println("트랙 종료: " + track.getInfo().title + " (이유: " + endReason + ")");
-            nextTrack();
         }
+        nextTrack(!keepConnection);
     }
 
     private void cleanupIfTts(AudioTrack track) {

--- a/src/main/java/com/gahyeonbot/services/assistant/VoiceAssistantService.java
+++ b/src/main/java/com/gahyeonbot/services/assistant/VoiceAssistantService.java
@@ -211,7 +211,7 @@ public class VoiceAssistantService {
                         segment, properties.getTtsProvider());
                 audioManager.getPlayerManager().loadItem(audio.toString(), new AudioLoadResultHandler() {
                     @Override public void trackLoaded(AudioTrack track) {
-                        track.setUserData(new TtsTrackMetadata(audio, true));
+                        track.setUserData(new TtsTrackMetadata(audio, true, true));
                         musicManager.playOrQueueTrack(track);
                     }
                     @Override public void playlistLoaded(AudioPlaylist playlist) {

--- a/src/main/java/com/gahyeonbot/services/tts/TtsTrackMetadata.java
+++ b/src/main/java/com/gahyeonbot/services/tts/TtsTrackMetadata.java
@@ -5,5 +5,8 @@ import java.nio.file.Path;
 /**
  * Stored as Lavaplayer track userData to allow cleanup on track end.
  */
-public record TtsTrackMetadata(Path wavPath, boolean deleteOnEnd) {}
-
+public record TtsTrackMetadata(Path wavPath, boolean deleteOnEnd, boolean keepConnection) {
+    public TtsTrackMetadata(Path wavPath, boolean deleteOnEnd) {
+        this(wavPath, deleteOnEnd, false);
+    }
+}


### PR DESCRIPTION
Prevents the shared audio scheduler from disconnecting after an assistant TTS response finishes. Regular TTS and music retain their existing disconnect behavior.\n\nValidated with `./gradlew clean test bootJar`.