### PR TITLE
Fall back to Java sentence splitting for TTS

### DIFF
--- a/src/main/java/com/gahyeonbot/services/tts/TtsService.java
+++ b/src/main/java/com/gahyeonbot/services/tts/TtsService.java
@@ -77,7 +77,13 @@ public class TtsService {
     }
 
     private List<String> splitAndChunk(String text) throws Exception {
-        List<String> sentences = splitSentences(text);
+        List<String> sentences;
+        try {
+            sentences = splitSentences(text);
+        } catch (Exception e) {
+            log.warn("KSS 문장 분리기를 사용할 수 없어 Java 분리기로 대체합니다: {}", e.getMessage());
+            sentences = splitSentencesLocally(text);
+        }
         List<String> out = new ArrayList<>();
         int max = Math.max(20, props.getSegmentMaxChars());
         for (String s : sentences) {
@@ -95,6 +101,17 @@ public class TtsService {
             }
         }
         return out;
+    }
+
+    static List<String> splitSentencesLocally(String text) {
+        if (text == null || text.isBlank()) return List.of();
+        String[] parts = text.trim().split("(?<=[.!?。！？])\\s+|\\R+");
+        List<String> sentences = new ArrayList<>(parts.length);
+        for (String part : parts) {
+            String trimmed = part.trim();
+            if (!trimmed.isEmpty()) sentences.add(trimmed);
+        }
+        return sentences.isEmpty() ? List.of(text.trim()) : sentences;
     }
 
     private List<String> splitSentences(String text) throws Exception {

--- a/src/test/java/com/gahyeonbot/services/tts/TtsServiceSentenceSplitTest.java
+++ b/src/test/java/com/gahyeonbot/services/tts/TtsServiceSentenceSplitTest.java
@@ -1,0 +1,24 @@
+package com.gahyeonbot.services.tts;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TtsServiceSentenceSplitTest {
+    @Test
+    void splitsKoreanSentencesWithoutPython() {
+        assertEquals(
+                List.of("첫 번째 문장입니다.", "두 번째 문장인가요?", "네, 맞습니다!"),
+                TtsService.splitSentencesLocally(
+                        "첫 번째 문장입니다. 두 번째 문장인가요? 네, 맞습니다!"));
+    }
+
+    @Test
+    void splitsLinesAndIgnoresBlankInput() {
+        assertEquals(List.of("첫째", "둘째"),
+                TtsService.splitSentencesLocally("첫째\n둘째"));
+        assertEquals(List.of(), TtsService.splitSentencesLocally("  "));
+    }
+}


### PR DESCRIPTION
Uses an in-process Java sentence splitter when the optional KSS Python runtime is unavailable, allowing Voicebox assistant synthesis to proceed in the JRE container. Includes regression tests.\n\nValidated with `./gradlew clean test bootJar`.