### PR TITLE
feat: add dedicated assistant channels

### DIFF
--- a/src/main/java/com/gahyeonbot/commands/general/Setup.java
+++ b/src/main/java/com/gahyeonbot/commands/general/Setup.java
@@ -1,0 +1,87 @@
+package com.gahyeonbot.commands.general;
+
+import com.gahyeonbot.commands.util.AbstractCommand;
+import com.gahyeonbot.commands.util.ResponseUtil;
+import com.gahyeonbot.services.assistant.GuildAssistantChannelsService;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.channel.concrete.Category;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.DiscordLocale;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class Setup extends AbstractCommand {
+    private static final String CATEGORY_NAME = "가현봇";
+    private static final String TEXT_CHANNEL_NAME = "가현봇-채팅";
+    private static final String VOICE_CHANNEL_NAME = "가현봇-비서";
+
+    private final GuildAssistantChannelsService channelsService;
+
+    @Override public String getName() { return "setup"; }
+    @Override public Map<DiscordLocale, String> getNameLocalizations() { return localizeKorean("설정"); }
+    @Override public String getDescription() { return "가현봇 전용 채팅·음성 채널을 설정합니다."; }
+    @Override public String getDetailedDescription() { return "/설정"; }
+    @Override public List<OptionData> getOptions() { return List.of(); }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        Guild guild = event.getGuild();
+        if (guild == null || event.getMember() == null) {
+            ResponseUtil.replyError(event, "서버 안에서만 사용할 수 있습니다.");
+            return;
+        }
+        if (!event.getMember().hasPermission(Permission.MANAGE_CHANNEL)) {
+            ResponseUtil.replyError(event, "채널 관리 권한이 있는 사용자만 설정할 수 있습니다.");
+            return;
+        }
+        if (guild.getSelfMember() == null
+                || !guild.getSelfMember().hasPermission(Permission.MANAGE_CHANNEL)) {
+            ResponseUtil.replyError(event, "가현봇에 채널 관리 권한을 먼저 부여해 주세요.");
+            return;
+        }
+
+        event.deferReply(true).queue();
+        try {
+            var saved = channelsService.find(guild.getIdLong()).orElse(null);
+            Category category = saved == null ? null : guild.getCategoryById(saved.getCategoryId());
+            TextChannel text = saved == null ? null : guild.getTextChannelById(saved.getTextChannelId());
+            VoiceChannel voice = saved == null ? null : guild.getVoiceChannelById(saved.getVoiceChannelId());
+
+            if (category == null) {
+                category = guild.getCategoriesByName(CATEGORY_NAME, true).stream().findFirst().orElse(null);
+            }
+            if (category == null) category = guild.createCategory(CATEGORY_NAME).complete();
+            if (text == null) {
+                text = category.getTextChannels().stream()
+                        .filter(channel -> channel.getName().equalsIgnoreCase(TEXT_CHANNEL_NAME))
+                        .findFirst().orElse(null);
+            }
+            if (text == null) text = category.createTextChannel(TEXT_CHANNEL_NAME).complete();
+            if (voice == null) {
+                voice = category.getVoiceChannels().stream()
+                        .filter(channel -> channel.getName().equalsIgnoreCase(VOICE_CHANNEL_NAME))
+                        .findFirst().orElse(null);
+            }
+            if (voice == null) voice = category.createVoiceChannel(VOICE_CHANNEL_NAME).complete();
+
+            channelsService.save(
+                    guild.getIdLong(), category.getIdLong(), text.getIdLong(), voice.getIdLong(),
+                    event.getUser().getIdLong());
+            event.getHook().editOriginal(
+                    "설정 완료: " + text.getAsMention() + "에서 바로 채팅하고, **"
+                            + voice.getName() + "**에 들어가면 음성 비서가 자동으로 참여합니다.").queue();
+        } catch (Exception e) {
+            logger.error("가현봇 전용 채널 설정 실패 guild={}", guild.getIdLong(), e);
+            event.getHook().editOriginal("채널 설정에 실패했습니다. 가현봇의 채널 관리 권한을 확인해 주세요.").queue();
+        }
+    }
+}

--- a/src/main/java/com/gahyeonbot/core/BotInitializerRunner.java
+++ b/src/main/java/com/gahyeonbot/core/BotInitializerRunner.java
@@ -5,6 +5,8 @@ import com.gahyeonbot.config.AppCredentialsConfig;
 import com.gahyeonbot.core.command.CommandRegistry;
 import com.gahyeonbot.listeners.CommandManager;
 import com.gahyeonbot.listeners.ListenerManager;
+import com.gahyeonbot.listeners.AssistantVoiceChannelListener;
+import com.gahyeonbot.listeners.MessageListener;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.sharding.ShardManager;
 import org.slf4j.Logger;
@@ -36,6 +38,8 @@ public class BotInitializerRunner implements CommandLineRunner {
     private final AppCredentialsConfig config;
     private final CommandRegistry commandRegistry;
     private final DataSource dataSource;
+    private final MessageListener messageListener;
+    private final AssistantVoiceChannelListener assistantVoiceChannelListener;
 
     @Value("${bot.enabled:true}")
     private boolean botEnabled;
@@ -109,7 +113,8 @@ public class BotInitializerRunner implements CommandLineRunner {
         commandManager.setShardManager(shardManager);
         commandManager.synchronizeCommands().join();
 
-        ListenerManager listenerManager = new ListenerManager(shardManager, config, commandManager);
+        ListenerManager listenerManager = new ListenerManager(
+                shardManager, config, commandManager, messageListener, assistantVoiceChannelListener);
         listenerManager.registerListeners();
 
         logger.info("Discord 봇이 성공적으로 초기화되었습니다. (leadership={})", hasLeadership);

--- a/src/main/java/com/gahyeonbot/entity/GuildAssistantChannels.java
+++ b/src/main/java/com/gahyeonbot/entity/GuildAssistantChannels.java
@@ -1,0 +1,45 @@
+package com.gahyeonbot.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "guild_assistant_channels")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuildAssistantChannels {
+    @Id
+    @Column(name = "guild_id")
+    private Long guildId;
+
+    @Column(name = "category_id", nullable = false)
+    private Long categoryId;
+
+    @Column(name = "text_channel_id", nullable = false)
+    private Long textChannelId;
+
+    @Column(name = "voice_channel_id", nullable = false)
+    private Long voiceChannelId;
+
+    @Column(name = "created_by", nullable = false)
+    private Long createdBy;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/com/gahyeonbot/listeners/AssistantVoiceChannelListener.java
+++ b/src/main/java/com/gahyeonbot/listeners/AssistantVoiceChannelListener.java
@@ -1,0 +1,44 @@
+package com.gahyeonbot.listeners;
+
+import com.gahyeonbot.services.assistant.GuildAssistantChannelsService;
+import com.gahyeonbot.services.assistant.VoiceAssistantService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel;
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class AssistantVoiceChannelListener extends ListenerAdapter {
+    private final GuildAssistantChannelsService channelsService;
+    private final VoiceAssistantService voiceAssistantService;
+
+    @Override
+    public void onGuildVoiceUpdate(@NotNull GuildVoiceUpdateEvent event) {
+        if (event.getMember().getUser().isBot()) return;
+        var configured = channelsService.find(event.getGuild().getIdLong()).orElse(null);
+        if (configured == null) return;
+
+        AudioChannel joined = event.getChannelJoined();
+        if (joined != null && joined.getIdLong() == configured.getVoiceChannelId()) {
+            var textChannel = event.getGuild().getTextChannelById(configured.getTextChannelId());
+            if (textChannel == null) {
+                log.warn("자동 음성 비서 시작 실패: 전용 채팅 채널 없음 guild={}", event.getGuild().getIdLong());
+                return;
+            }
+            var result = voiceAssistantService.start(event.getGuild(), event.getMember(), textChannel);
+            if (result.started()) textChannel.sendMessage(result.message()).queue();
+            return;
+        }
+
+        AudioChannel left = event.getChannelLeft();
+        if (left != null && left.getIdLong() == configured.getVoiceChannelId()
+                && left.getMembers().stream().noneMatch(member -> !member.getUser().isBot())) {
+            voiceAssistantService.stop(event.getGuild());
+        }
+    }
+}

--- a/src/main/java/com/gahyeonbot/listeners/ListenerManager.java
+++ b/src/main/java/com/gahyeonbot/listeners/ListenerManager.java
@@ -14,6 +14,8 @@ public class ListenerManager {
     private final ShardManager shardManager;
     private final AppCredentialsConfig appCredentialsConfig;
     private final CommandManager commandManager;
+    private final MessageListener messageListener;
+    private final AssistantVoiceChannelListener assistantVoiceChannelListener;
 
     /**
      * ListenerManager 생성자.
@@ -22,18 +24,25 @@ public class ListenerManager {
      * @param appCredentialsConfig 설정 로더
      * @param commandManager 명령어 매니저
      */
-    public ListenerManager(ShardManager shardManager, AppCredentialsConfig appCredentialsConfig,CommandManager commandManager) {
+    public ListenerManager(
+            ShardManager shardManager,
+            AppCredentialsConfig appCredentialsConfig,
+            CommandManager commandManager,
+            MessageListener messageListener,
+            AssistantVoiceChannelListener assistantVoiceChannelListener) {
         this.shardManager = shardManager;
         this.appCredentialsConfig = appCredentialsConfig;
         this.commandManager = commandManager;
-
+        this.messageListener = messageListener;
+        this.assistantVoiceChannelListener = assistantVoiceChannelListener;
     }
 
     /**
      * 모든 이벤트 리스너를 ShardManager에 등록합니다.
      */
     public void registerListeners() {
-        shardManager.addEventListener(new MessageListener());
+        shardManager.addEventListener(messageListener);
+        shardManager.addEventListener(assistantVoiceChannelListener);
         shardManager.addEventListener(new MemberJoinListener());
         shardManager.addEventListener(new UserStatusUpdateListener(appCredentialsConfig));
         shardManager.addEventListener(commandManager);

--- a/src/main/java/com/gahyeonbot/listeners/MessageListener.java
+++ b/src/main/java/com/gahyeonbot/listeners/MessageListener.java
@@ -1,24 +1,80 @@
 package com.gahyeonbot.listeners;
 
+import com.gahyeonbot.services.ai.OpenAiService;
+import com.gahyeonbot.services.ai.agent.AgentApprovalRequiredException;
+import com.gahyeonbot.services.assistant.GuildAssistantChannelsService;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
 
-/**
- * Discord 메시지 이벤트를 처리하는 리스너 클래스.
- * 사용자가 보낸 메시지를 감지하고 처리합니다.
- * 
- * @author GahyeonBot Team
- * @version 1.0
- */
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Slf4j
+@Component
 public class MessageListener extends ListenerAdapter {
+    private final GuildAssistantChannelsService channelsService;
+    private final OpenAiService openAiService;
+    private final ExecutorService workers = Executors.newVirtualThreadPerTaskExecutor();
+
+    public MessageListener(GuildAssistantChannelsService channelsService, OpenAiService openAiService) {
+        this.channelsService = channelsService;
+        this.openAiService = openAiService;
+    }
+
     @Override
     public void onMessageReceived(@NotNull MessageReceivedEvent event) {
-        if (event.getAuthor().isBot()) return;
+        if (!event.isFromGuild() || event.getAuthor().isBot() || event.isWebhookMessage()) return;
+        var configured = channelsService.find(event.getGuild().getIdLong()).orElse(null);
+        if (configured == null || configured.getTextChannelId() != event.getChannel().getIdLong()) return;
 
-        String message = event.getMessage().getContentRaw();
-        if (message.contains("ping")) {
-            event.getChannel().sendMessage("pong2").queue();
+        String question = event.getMessage().getContentRaw().trim();
+        if (question.isEmpty()) return;
+        if (question.length() > 1000) {
+            event.getChannel().sendMessage("질문은 1000자 이하로 보내 주세요.").queue();
+            return;
         }
+        workers.submit(() -> answer(event, question));
+    }
+
+    private void answer(MessageReceivedEvent event, String question) {
+        try {
+            event.getChannel().sendTyping().queue();
+            String response = openAiService.chat(
+                    "message:" + event.getMessageId(),
+                    event.getAuthor().getIdLong(),
+                    event.getAuthor().getName(),
+                    event.getGuild().getIdLong(),
+                    question);
+            if (response == null || response.isBlank()) {
+                event.getChannel().sendMessage("AI 응답을 받지 못했습니다. 잠시 후 다시 시도해 주세요.").queue();
+                return;
+            }
+            sendChunks(event, response);
+        } catch (AgentApprovalRequiredException e) {
+            event.getChannel().sendMessage("도구 실행 승인이 필요해요. `/에이전트`에서 확인해 주세요. run: `"
+                    + e.getRunId() + "`").queue();
+        } catch (OpenAiService.RateLimitException | OpenAiService.AdversarialPromptException e) {
+            event.getChannel().sendMessage("⚠️ " + e.getMessage()).queue();
+        } catch (Exception e) {
+            log.error("전용 채팅 채널 AI 응답 실패 guild={} user={}",
+                    event.getGuild().getIdLong(), event.getAuthor().getIdLong(), e);
+            event.getChannel().sendMessage("처리 중 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.").queue();
+        }
+    }
+
+    private void sendChunks(MessageReceivedEvent event, String response) {
+        for (int start = 0; start < response.length(); start += 1900) {
+            event.getChannel().sendMessage(
+                    response.substring(start, Math.min(start + 1900, response.length()))).queue();
+        }
+    }
+
+    @PreDestroy
+    void shutdown() {
+        workers.shutdownNow();
     }
 }

--- a/src/main/java/com/gahyeonbot/repository/GuildAssistantChannelsRepository.java
+++ b/src/main/java/com/gahyeonbot/repository/GuildAssistantChannelsRepository.java
@@ -1,0 +1,8 @@
+package com.gahyeonbot.repository;
+
+import com.gahyeonbot.entity.GuildAssistantChannels;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GuildAssistantChannelsRepository extends JpaRepository<GuildAssistantChannels, Long> {
+}
+

--- a/src/main/java/com/gahyeonbot/services/assistant/GuildAssistantChannelsService.java
+++ b/src/main/java/com/gahyeonbot/services/assistant/GuildAssistantChannelsService.java
@@ -1,0 +1,43 @@
+package com.gahyeonbot.services.assistant;
+
+import com.gahyeonbot.entity.GuildAssistantChannels;
+import com.gahyeonbot.repository.GuildAssistantChannelsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class GuildAssistantChannelsService {
+    private final GuildAssistantChannelsRepository repository;
+
+    @Transactional(readOnly = true)
+    public Optional<GuildAssistantChannels> find(long guildId) {
+        return repository.findById(guildId);
+    }
+
+    @Transactional
+    public GuildAssistantChannels save(
+            long guildId,
+            long categoryId,
+            long textChannelId,
+            long voiceChannelId,
+            long createdBy) {
+        LocalDateTime now = LocalDateTime.now();
+        GuildAssistantChannels channels = repository.findById(guildId)
+                .orElseGet(() -> GuildAssistantChannels.builder()
+                        .guildId(guildId)
+                        .createdBy(createdBy)
+                        .createdAt(now)
+                        .build());
+        channels.setCategoryId(categoryId);
+        channels.setTextChannelId(textChannelId);
+        channels.setVoiceChannelId(voiceChannelId);
+        channels.setUpdatedAt(now);
+        return repository.save(channels);
+    }
+}
+

--- a/src/main/java/com/gahyeonbot/services/assistant/VoiceAssistantService.java
+++ b/src/main/java/com/gahyeonbot/services/assistant/VoiceAssistantService.java
@@ -56,20 +56,25 @@ public class VoiceAssistantService {
                 || requester.getVoiceState().getChannel() == null) {
             return new StartResult(false, "먼저 음성 채널에 입장해 주세요.");
         }
-        if (sessions.containsKey(guild.getIdLong())) {
-            return new StartResult(false, "이 서버에서는 이미 비서 세션이 실행 중입니다.");
-        }
-
         AudioChannel channel = requester.getVoiceState().getChannel();
         GuildMusicManager musicManager = musicService.getOrCreateGuildMusicManager(guild);
         Session session = new Session(guild, channel, textChannel, musicManager);
-        sessions.put(guild.getIdLong(), session);
+        if (sessions.putIfAbsent(guild.getIdLong(), session) != null) {
+            session.close();
+            return new StartResult(false, "이 서버에서는 이미 비서 세션이 실행 중입니다.");
+        }
 
-        var manager = guild.getAudioManager();
-        manager.setSelfDeafened(false);
-        manager.setSendingHandler(musicManager.getSendHandler());
-        manager.setReceivingHandler(session.receiver);
-        manager.openAudioConnection(channel);
+        try {
+            var manager = guild.getAudioManager();
+            manager.setSelfDeafened(false);
+            manager.setSendingHandler(musicManager.getSendHandler());
+            manager.setReceivingHandler(session.receiver);
+            manager.openAudioConnection(channel);
+        } catch (RuntimeException e) {
+            sessions.remove(guild.getIdLong(), session);
+            session.close();
+            throw e;
+        }
         return new StartResult(true,
                 "음성 비서 세션을 시작했습니다. 종료 전까지 참여자의 음성이 외부 STT/AI로 전송되고 전사문이 이 채널에 표시됩니다.");
     }

--- a/src/main/resources/db/migration/V19__Add_guild_assistant_channels.sql
+++ b/src/main/resources/db/migration/V19__Add_guild_assistant_channels.sql
@@ -1,0 +1,10 @@
+CREATE TABLE guild_assistant_channels (
+    guild_id BIGINT PRIMARY KEY,
+    category_id BIGINT NOT NULL,
+    text_channel_id BIGINT NOT NULL,
+    voice_channel_id BIGINT NOT NULL,
+    created_by BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);
+


### PR DESCRIPTION
변경 사항: /설정으로 서버별 전용 채팅·음성 채널을 만들고, 일반 채팅을 AI 런타임으로 처리하며, 음성 채널 입퇴장에 따라 비서를 자동 시작·종료합니다. 서버별 설정을 저장하고 중복 생성을 방지합니다. 검증: 전체 Gradle 테스트와 develop Build & Test, Build Image validation 성공.